### PR TITLE
use noble (latest ubuntu LTS version)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,8 @@ locals {
     ubuntu = {
       owners = ["099720109477"] # canonical
       filters = {
-        "arm64" = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"]
-        "x64"   = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+        "arm64" = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"]
+        "x64"   = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
       }
     }
   }


### PR DESCRIPTION
The standard Ubuntu Node.js package (v12) is no longer compatible with our Sonar action. Updating the AMI to use the latest LTS version of Ubuntu (24.04) resolves this issue, as it includes Node.js LTS v16.

GitHub will soon update their hosted runners to use the "noble" version, which gives me confidence in making this change as well. 😊

[Collect workflow inputs](https://github.com/tx-pts-dai/terraform-aws-ec2-actions-runners/actions/runs/12184055040/job/33987003905)
ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636
